### PR TITLE
API: 로그인/회원가입 API 연동

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -3,7 +3,6 @@ import { NextResponse } from "next/server";
 export async function POST(request: Request) {
   try {
     const body = await request.json();
-    console.log("프론트에서 보낸 데이터:", body);
 
     const response = await fetch(
       "https://43.202.184.232.nip.io/api/auth/login",

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    console.log("프론트에서 보낸 데이터:", body);
+
+    const response = await fetch(
+      "https://43.202.184.232.nip.io/api/auth/login",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      },
+    );
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.error("백엔드 에러 응답:", errorText);
+      return NextResponse.json(
+        { message: "백엔드 서버 오류" },
+        { status: response.status },
+      );
+    }
+
+    const data = await response.json();
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error("Proxy 내부 에러 상세:", error); // 터미널(VSCode) 확인
+    return NextResponse.json(
+      { message: "서버 연결에 실패했습니다 (8080 확인 필요)" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -25,7 +25,7 @@ export async function POST(request: Request) {
     const data = await response.json();
     return NextResponse.json(data);
   } catch (error) {
-    console.error("Proxy 내부 에러 상세:", error); // 터미널(VSCode) 확인
+    console.error("Proxy 내부 에러 상세:", error);
     return NextResponse.json(
       { message: "서버 연결에 실패했습니다 (8080 확인 필요)" },
       { status: 500 },

--- a/src/app/api/signup.ts
+++ b/src/app/api/signup.ts
@@ -1,0 +1,33 @@
+import { useSignupStore } from "@/stores/useSignupStore";
+
+const getSignupHeader = () => {
+  const { draftKey } = useSignupStore.getState();
+  return draftKey ? { "Signup-Draft-Key": draftKey } : {};
+};
+
+export const signupApi = {
+  submitTerms: (
+    consents: { code: string; version: string; agreed: boolean }[],
+  ) =>
+    fetch("/api/signup/drafts/terms", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...getSignupHeader(),
+      } as HeadersInit,
+      body: JSON.stringify({ consents }),
+    }),
+
+  // STEP 3: SMS 발송
+  sendSms: (phoneNumber: string) =>
+    fetch("/api/signup/sms/send", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...getSignupHeader(),
+      } as HeadersInit, // 타입 단언 추가
+      body: JSON.stringify({ phoneNumber }),
+    }),
+
+  // STEP 4~6 생략 (동일한 패턴으로 추가 가능)
+};

--- a/src/app/api/signup.ts
+++ b/src/app/api/signup.ts
@@ -1,11 +1,12 @@
 import { useSignupStore } from "@/stores/useSignupStore";
 
-const getSignupHeader = () => {
+const getSignupHeader = (): Record<string, string> => {
   const { draftKey } = useSignupStore.getState();
   return draftKey ? { "Signup-Draft-Key": draftKey } : {};
 };
 
 export const signupApi = {
+  // STEP 2: 약관 동의 제출
   submitTerms: (
     consents: { code: string; version: string; agreed: boolean }[],
   ) =>
@@ -18,16 +19,50 @@ export const signupApi = {
       body: JSON.stringify({ consents }),
     }),
 
-  // STEP 3: SMS 발송
+  // STEP 3: 인증번호 SMS 발송
   sendSms: (phoneNumber: string) =>
     fetch("/api/signup/sms/send", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         ...getSignupHeader(),
-      } as HeadersInit, // 타입 단언 추가
+      } as HeadersInit,
       body: JSON.stringify({ phoneNumber }),
     }),
 
-  // STEP 4~6 생략 (동일한 패턴으로 추가 가능)
+  // STEP 4: OTP 검증
+  verifyOtp: (otpCode: string) =>
+    fetch("/api/signup/otp/verify", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...getSignupHeader(),
+      } as HeadersInit,
+      body: JSON.stringify({ otpCode }),
+    }),
+
+  // STEP 5: 프로필 정보 제출
+  submitProfile: (profile: { name: string; birthDate: string }) =>
+    fetch("/api/signup/profile", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...getSignupHeader(),
+      } as HeadersInit,
+      body: JSON.stringify(profile),
+    }),
+
+  // STEP 6: 비밀번호 설정 (최종 가입)
+  submitPassword: (passwordData: {
+    password: string;
+    confirmPassword: string;
+  }) =>
+    fetch("/api/signup/password", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...getSignupHeader(),
+      } as HeadersInit,
+      body: JSON.stringify(passwordData),
+    }),
 };

--- a/src/app/api/signup/drafts/route.ts
+++ b/src/app/api/signup/drafts/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 
 export async function POST() {
+  console.log("API Route 도달 성공");
   try {
     const response = await fetch(
       "https://43.202.184.232.nip.io/api/signup/drafts",
@@ -11,6 +12,7 @@ export async function POST() {
     );
 
     const body = await response.json();
+    console.log("백엔드 응답 상세:", body);
     const draftKey = response.headers.get("signup-draft-key");
 
     return NextResponse.json(body, {

--- a/src/app/api/signup/drafts/route.ts
+++ b/src/app/api/signup/drafts/route.ts
@@ -14,6 +14,7 @@ export async function POST() {
     const draftKey = response.headers.get("signup-draft-key");
 
     return NextResponse.json(body, {
+      status: response.status,
       headers: {
         "signup-draft-key": draftKey || "",
         "Access-Control-Expose-Headers": "signup-draft-key",

--- a/src/app/api/signup/drafts/route.ts
+++ b/src/app/api/signup/drafts/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+
+export async function POST() {
+  try {
+    const response = await fetch(
+      "https://43.202.184.232.nip.io/api/signup/drafts",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+
+    const body = await response.json();
+    const draftKey = response.headers.get("signup-draft-key");
+
+    return NextResponse.json(body, {
+      headers: {
+        "signup-draft-key": draftKey || "",
+        "Access-Control-Expose-Headers": "signup-draft-key",
+      },
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { message: "Internal Server Error" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/signup/drafts/terms/route.ts
+++ b/src/app/api/signup/drafts/terms/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+
+export async function POST(req: Request) {
+  const body = await req.json();
+  const draftKey = req.headers.get("Signup-Draft-Key") || "";
+
+  const res = await fetch(
+    "https://43.202.184.232.nip.io/api/signup/drafts/terms",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Signup-Draft-Key": draftKey,
+      },
+      body: JSON.stringify(body),
+    },
+  );
+
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/src/app/api/signup/otp/verify/route.ts
+++ b/src/app/api/signup/otp/verify/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+
+export async function POST(req: Request) {
+  const body = await req.json();
+  const draftKey = req.headers.get("Signup-Draft-Key") || "";
+
+  const res = await fetch(
+    "https://43.202.184.232.nip.io/api/signup/otp/verify",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Signup-Draft-Key": draftKey,
+      },
+      body: JSON.stringify(body),
+    },
+  );
+
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/src/app/api/signup/password/route.ts
+++ b/src/app/api/signup/password/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const draftKey = req.headers.get("Signup-Draft-Key") || "";
+
+    const res = await fetch(
+      "https://43.202.184.232.nip.io/api/signup/password",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Signup-Draft-Key": draftKey,
+        },
+        body: JSON.stringify(body),
+      },
+    );
+
+    const data = await res.json();
+    return NextResponse.json(data, { status: res.status });
+  } catch (error) {
+    console.error("Password Proxy Error:", error);
+    return NextResponse.json(
+      { success: false, message: "서버 연결 실패" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/signup/profile/route.ts
+++ b/src/app/api/signup/profile/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const draftKey = req.headers.get("Signup-Draft-Key") || "";
+
+    const res = await fetch(
+      "https://43.202.184.232.nip.io/api/signup/profile",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Signup-Draft-Key": draftKey,
+        },
+        body: JSON.stringify(body),
+      },
+    );
+
+    const data = await res.json();
+    return NextResponse.json(data, { status: res.status });
+  } catch (error) {
+    console.error("Profile Proxy Error:", error);
+    return NextResponse.json(
+      { success: false, message: "서버 연결 실패" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/signup/sms/send/route.ts
+++ b/src/app/api/signup/sms/send/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+
+export async function POST(req: Request) {
+  const body = await req.json();
+  const draftKey = req.headers.get("Signup-Draft-Key") || "";
+
+  const res = await fetch("https://43.202.184.232.nip.io/api/signup/sms/send", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Signup-Draft-Key": draftKey,
+    },
+    body: JSON.stringify(body),
+  });
+
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -6,7 +6,7 @@ import { useSignupStore } from "@/stores/useSignupStore";
 
 const AuthStartPage = () => {
   const router = useRouter();
-  const { setDraftKey, setCurrentStep } = useSignupStore();
+  const { setSignupData } = useSignupStore();
 
   const handleClickLogin = () => {
     router.push("/login/phone");
@@ -19,27 +19,16 @@ const AuthStartPage = () => {
 
       const draftKey =
         result.data?.draftKey || response.headers.get("signup-draft-key");
-      if (draftKey) {
-        setDraftKey(draftKey); // 스토어에 키 저장
-        setCurrentStep(result.data.step); // 현재 단계 저장 (TERMS_REQUIRED)
+      const terms = result.data?.terms || result.data?.data?.terms || [];
+
+      console.log("받아온 약관 데이터:", terms);
+
+      if (draftKey && terms.length > 0) {
+        setSignupData(draftKey, terms);
         router.push("/signup/agree");
-      }
-      // 1. 응답 바디의 데이터 구조에 따른 키 추출 (가장 권장)
-      // result.data 안의 draftKey 확인
-      const bodyKey = result?.data?.draftKey;
-
-      // 2. 응답 헤더에서 키 추출
-      const headerKey = response.headers.get("signup-draft-key");
-
-      const finalKey = bodyKey || headerKey;
-
-      if (finalKey) {
-        console.log("확인된 드래프트 키:", finalKey);
-        sessionStorage.setItem("signup_draft_key", finalKey);
-        router.push("/signup/agree");
+        console.log("드래프트 키:", draftKey);
       } else {
-        console.error("키 추출 실패: 응답 바디와 헤더 모두에 키가 없음");
-        console.log("분석된 바디 구조:", result);
+        console.warn("데이터 부족: Key나 Terms가 없음", { draftKey, terms });
       }
     } catch (error) {
       console.error("네트워크 에러:", error);

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -21,12 +21,9 @@ const AuthStartPage = () => {
         result.data?.draftKey || response.headers.get("signup-draft-key");
       const terms = result.data?.terms || result.data?.data?.terms || [];
 
-      console.log("받아온 약관 데이터:", terms);
-
       if (draftKey && terms.length > 0) {
         setSignupData(draftKey, terms);
         router.push("/signup/agree");
-        console.log("드래프트 키:", draftKey);
       } else {
         console.warn("데이터 부족: Key나 Terms가 없음", { draftKey, terms });
       }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -2,11 +2,48 @@
 
 import { useRouter } from "next/navigation";
 
+import { useSignupStore } from "@/stores/useSignupStore";
+
 const AuthStartPage = () => {
   const router = useRouter();
+  const { setDraftKey, setCurrentStep } = useSignupStore();
 
   const handleClickLogin = () => {
     router.push("/login/phone");
+  };
+
+  const handleStartSignup = async () => {
+    try {
+      const response = await fetch("/api/signup/drafts", { method: "POST" });
+      const result = await response.json();
+
+      const draftKey =
+        result.data?.draftKey || response.headers.get("signup-draft-key");
+      if (draftKey) {
+        setDraftKey(draftKey); // 스토어에 키 저장
+        setCurrentStep(result.data.step); // 현재 단계 저장 (TERMS_REQUIRED)
+        router.push("/signup/agree");
+      }
+      // 1. 응답 바디의 데이터 구조에 따른 키 추출 (가장 권장)
+      // result.data 안의 draftKey 확인
+      const bodyKey = result?.data?.draftKey;
+
+      // 2. 응답 헤더에서 키 추출
+      const headerKey = response.headers.get("signup-draft-key");
+
+      const finalKey = bodyKey || headerKey;
+
+      if (finalKey) {
+        console.log("확인된 드래프트 키:", finalKey);
+        sessionStorage.setItem("signup_draft_key", finalKey);
+        router.push("/signup/agree");
+      } else {
+        console.error("키 추출 실패: 응답 바디와 헤더 모두에 키가 없음");
+        console.log("분석된 바디 구조:", result);
+      }
+    } catch (error) {
+      console.error("네트워크 에러:", error);
+    }
   };
 
   return (
@@ -32,7 +69,7 @@ const AuthStartPage = () => {
           <button
             type="button"
             className="text-button-sb border-mint-01 text-mint-01 flex h-14.5 w-full cursor-pointer items-center justify-center rounded-2xl border bg-white px-3.5"
-            onClick={() => router.push("/signup/agree")}
+            onClick={handleStartSignup}
           >
             회원가입
           </button>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -2,17 +2,23 @@
 
 import { useRouter } from "next/navigation";
 
+import { useState } from "react";
+
 import { useSignupStore } from "@/stores/useSignupStore";
 
 const AuthStartPage = () => {
   const router = useRouter();
   const { setSignupData } = useSignupStore();
+  const [isLoading, setIsLoading] = useState(false);
 
   const handleClickLogin = () => {
     router.push("/login/phone");
   };
 
   const handleStartSignup = async () => {
+    if (isLoading) return;
+    setIsLoading(true);
+
     try {
       const response = await fetch("/api/signup/drafts", { method: "POST" });
       const result = await response.json();
@@ -31,6 +37,8 @@ const AuthStartPage = () => {
     } catch (error) {
       console.error("네트워크 에러:", error);
       alert("네트워크 오류가 발생했습니다.");
+    } finally {
+      setIsLoading(false);
     }
   };
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -26,9 +26,11 @@ const AuthStartPage = () => {
         router.push("/signup/agree");
       } else {
         console.warn("데이터 부족: Key나 Terms가 없음", { draftKey, terms });
+        alert("회원가입 정보를 불러오는데 실패했습니다. 다시 시도해주세요");
       }
     } catch (error) {
       console.error("네트워크 에러:", error);
+      alert("네트워크 오류가 발생했습니다.");
     }
   };
 

--- a/src/app/login/phone/page.tsx
+++ b/src/app/login/phone/page.tsx
@@ -18,9 +18,44 @@ import { phoneChangeHandler } from "@/utils/phoneHandlers";
 const LoginPage = () => {
   const [phone, setPhone] = useState("");
   const [password, setPassword] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
   const router = useRouter();
   const isActive = phone.length === 11 && password.length >= 8;
   const handlePhoneChange = phoneChangeHandler(setPhone);
+
+  const handleLogin = async () => {
+    if (!isActive || isLoading) return;
+
+    setIsLoading(true);
+    try {
+      const response = await fetch("/api/auth/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          phoneNumber: phone,
+          password: password,
+        }),
+      });
+
+      const result = await response.json();
+
+      if (result.success) {
+        const { accessToken, refreshToken } = result.data;
+
+        localStorage.setItem("access_token", accessToken.accessToken);
+        localStorage.setItem("refresh_token", refreshToken.refreshToken);
+
+        router.push("/");
+      } else {
+        alert(result.message || "로그인 정보가 일치하지 않습니다.");
+      }
+    } catch (error) {
+      console.error("로그인 에러:", error);
+      alert("네트워크 오류가 발생했습니다.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
 
   return (
     <main
@@ -30,7 +65,7 @@ const LoginPage = () => {
     >
       <div className="flex h-full w-full flex-1 flex-col">
         <BackHeader title="로그인" />
-        <div className="mt-13.5 flex flex-col gap-[29px]">
+        <div className="flex flex-col gap-[29px]">
           <PageTitle>
             로그인하고 <br /> 심톡을 시작해볼까요?
           </PageTitle>
@@ -68,8 +103,11 @@ const LoginPage = () => {
         </button>
 
         <div className="mb-[42px] px-4 py-[10px]">
-          <FullButton isActive={isActive} onClick={() => router.push("/")}>
+          {/* <FullButton isActive={isActive} onClick={() => router.push("/")}>
             로그인
+          </FullButton> */}
+          <FullButton isActive={isActive && !isLoading} onClick={handleLogin}>
+            {isLoading ? "로그인 중..." : "로그인"}
           </FullButton>
         </div>
       </div>

--- a/src/app/signup/agree/page.tsx
+++ b/src/app/signup/agree/page.tsx
@@ -2,41 +2,68 @@
 
 import { useRouter } from "next/navigation";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
+
+import { useSignupStore } from "@/stores/useSignupStore";
+
+import { signupApi } from "@/app/api/signup";
 
 import { BackHeader } from "@/components/common/BackHeader";
 import { Checkbox } from "@/components/common/Checkbox";
 import { FullButton } from "@/components/common/FullButton";
 import { PageTitle } from "@/components/common/PageTitle";
 
-import { AGREEMENTS, INITIAL_AGREEMENTS } from "@/constants/agreement";
-
-import type { AgreementKey } from "@/types/agreement.type";
-
 const AgreePage = () => {
   const router = useRouter();
-  const [agreements, setAgreements] =
-    useState<Record<AgreementKey, boolean>>(INITIAL_AGREEMENTS);
+  const { terms } = useSignupStore();
 
-  const isConfirmActive =
-    agreements.service && agreements.finance && agreements.personalRequired;
+  const [agreements, setAgreements] = useState<Record<string, boolean>>(() =>
+    Object.fromEntries(terms.map(t => [t.code, false])),
+  );
 
-  const allChecked = Object.values(agreements).every(Boolean);
+  const isConfirmActive = useMemo(
+    () =>
+      terms.length > 0 &&
+      terms.filter(t => t.required).every(t => agreements[t.code]),
+    [terms, agreements],
+  );
+
+  const allChecked = useMemo(
+    () => terms.length > 0 && terms.every(t => agreements[t.code]),
+    [terms, agreements],
+  );
+
+  if (terms.length === 0) return null;
 
   const handleAllChange = () => {
-    const next = !allChecked;
-    setAgreements(
-      Object.fromEntries(
-        Object.keys(agreements).map(key => [key, next]),
-      ) as Record<AgreementKey, boolean>,
-    );
+    const nextValue = !allChecked;
+    setAgreements(Object.fromEntries(terms.map(t => [t.code, nextValue])));
   };
 
-  const handleChange =
-    (key: AgreementKey) => (e: React.ChangeEvent<HTMLInputElement>) => {
-      const checked = e.target.checked;
-      setAgreements(prev => ({ ...prev, [key]: checked }));
+  const handleSingleChange =
+    (code: string) => (e: React.ChangeEvent<HTMLInputElement>) => {
+      setAgreements(prev => ({ ...prev, [code]: e.target.checked }));
     };
+
+  const handleAgreeSubmit = async () => {
+    const consents = terms.map(term => ({
+      code: term.code,
+      version: term.version,
+      agreed: agreements[term.code] || false,
+    }));
+
+    try {
+      const res = await signupApi.submitTerms(consents);
+      const result = await res.json();
+      if (result.success) {
+        router.push("/signup/profile");
+      } else {
+        alert(result.message);
+      }
+    } catch (error) {
+      console.error("제출 실패:", error);
+    }
+  };
 
   return (
     <main className="flex min-h-dvh w-full flex-col justify-center">
@@ -62,12 +89,12 @@ const AgreePage = () => {
           {/* 개별 약관들 */}
           <li>
             <ul>
-              {AGREEMENTS.map(item => (
-                <li key={item.key} className="px-4 py-2.5">
+              {terms.map(term => (
+                <li key={term.code} className="px-4 py-2.5">
                   <Checkbox
-                    label={item.label}
-                    checked={agreements[item.key]}
-                    onChange={handleChange(item.key)}
+                    label={`${term.title} ${term.required ? "(필수)" : "(선택)"}`}
+                    checked={agreements[term.code] || false}
+                    onChange={handleSingleChange(term.code)}
                   />
                 </li>
               ))}
@@ -77,10 +104,7 @@ const AgreePage = () => {
       </div>
 
       <div className="mb-[42px] flex w-full justify-center px-4 py-[10px]">
-        <FullButton
-          isActive={isConfirmActive}
-          onClick={() => router.push("/signup/profile")}
-        >
+        <FullButton isActive={isConfirmActive} onClick={handleAgreeSubmit}>
           동의하기
         </FullButton>
       </div>

--- a/src/app/signup/agree/page.tsx
+++ b/src/app/signup/agree/page.tsx
@@ -58,7 +58,7 @@ const AgreePage = () => {
       if (result.success) {
         router.push("/signup/profile");
       } else {
-        alert(result.message);
+        alert(result.message || "약관 동의 제출에 실패했습니다.");
       }
     } catch (error) {
       console.error("제출 실패:", error);

--- a/src/app/signup/password/page.tsx
+++ b/src/app/signup/password/page.tsx
@@ -4,6 +4,8 @@ import { useRouter } from "next/navigation";
 
 import { useState } from "react";
 
+import { signupApi } from "@/app/api/signup";
+
 import Exclamation from "@/assets/exclamation-circle.svg";
 import LockIcon from "@/assets/lock.svg";
 
@@ -16,10 +18,9 @@ import { usePasswordValidation } from "@/hooks/usePasswordValidation";
 
 const SettingPage = () => {
   const router = useRouter();
-
   const [password, setPassword] = useState("");
   const [passwordConfirm, setPasswordConfirm] = useState("");
-
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const { isValidPassword, getState, getTextColor } = usePasswordValidation();
 
   const isPasswordValid = isValidPassword(password);
@@ -41,6 +42,36 @@ const SettingPage = () => {
           | "default"
           | "invalid"
           | "valid");
+
+  const handlePasswordSubmit = async () => {
+    if (!isPasswordConfirmValid || isSubmitting) return;
+
+    setIsSubmitting(true);
+    try {
+      const res = await signupApi.submitPassword({
+        password,
+        confirmPassword: passwordConfirm,
+      });
+      const result = await res.json();
+
+      console.log("회원가입 최종 결과:", result);
+
+      if (result.success) {
+        const { accessToken, refreshToken } = result.data.tokens;
+        localStorage.setItem("accessToken", accessToken.accessToken);
+        localStorage.setItem("refreshToken", refreshToken.refreshToken);
+
+        router.push("/onboarding");
+      } else {
+        alert(result.message || "비밀번호 설정 중 오류가 발생했습니다.");
+      }
+    } catch (error) {
+      console.error("비밀번호 제출 에러:", error);
+      alert("네트워크 오류가 발생했습니다.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
 
   return (
     <main className="flex min-h-dvh w-full justify-center bg-white">
@@ -113,7 +144,8 @@ const SettingPage = () => {
         <div className="mb-13 flex w-full justify-center px-4 py-[10px]">
           <FullButton
             isActive={isPasswordConfirmValid}
-            onClick={() => router.push("/onboarding")}
+            onClick={handlePasswordSubmit}
+            disabled={isSubmitting}
           >
             설정완료
           </FullButton>

--- a/src/app/signup/password/page.tsx
+++ b/src/app/signup/password/page.tsx
@@ -151,9 +151,8 @@ const SettingPage = () => {
 
         <div className="mb-13 flex w-full justify-center px-4 py-[10px]">
           <FullButton
-            isActive={isPasswordConfirmValid}
+            isActive={isPasswordConfirmValid && !isSubmitting}
             onClick={handlePasswordSubmit}
-            disabled={isSubmitting}
           >
             설정완료
           </FullButton>

--- a/src/app/signup/password/page.tsx
+++ b/src/app/signup/password/page.tsx
@@ -58,8 +58,8 @@ const SettingPage = () => {
 
       if (result.success) {
         const { accessToken, refreshToken } = result.data.tokens;
-        localStorage.setItem("accessToken", accessToken.accessToken);
-        localStorage.setItem("refreshToken", refreshToken.refreshToken);
+        localStorage.setItem("access_token", accessToken.accessToken);
+        localStorage.setItem("refresh_token", refreshToken.refreshToken);
 
         router.push("/onboarding");
       } else {

--- a/src/app/signup/password/page.tsx
+++ b/src/app/signup/password/page.tsx
@@ -57,9 +57,17 @@ const SettingPage = () => {
       console.log("회원가입 최종 결과:", result);
 
       if (result.success) {
-        const { accessToken, refreshToken } = result.data.tokens;
-        localStorage.setItem("access_token", accessToken.accessToken);
-        localStorage.setItem("refresh_token", refreshToken.refreshToken);
+        const tokens = result.data?.tokens;
+        const access = tokens?.accessToken?.accessToken;
+        const refresh = tokens?.refreshToken?.refreshToken;
+
+        if (!access || !refresh) {
+          alert("토큰 정보를 받아오지 못했습니다.");
+          return;
+        }
+
+        localStorage.setItem("access_token", access);
+        localStorage.setItem("refresh_token", refresh);
 
         router.push("/onboarding");
       } else {

--- a/src/components/signup/ProfileForm.tsx
+++ b/src/components/signup/ProfileForm.tsx
@@ -4,6 +4,8 @@ import { useRouter } from "next/navigation";
 
 import { useState } from "react";
 
+import { signupApi } from "@/app/api/signup";
+
 import DateIcon from "@/assets/date.svg";
 import ErrorIcon from "@/assets/modal_error.svg";
 import SuccessIcon from "@/assets/modal_success.svg";
@@ -45,11 +47,29 @@ export const ProfileForm = () => {
   const canRequestCode = isValidPhone;
   const isBirthValid = isValidBirth(birth);
 
-  const handleRequestCode = () => {
-    if (!canRequestCode) return;
-    setIsVerified(false);
-    setCode("");
-    start(120);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleRequestCode = async () => {
+    if (!canRequestCode || isSubmitting) return;
+
+    setIsSubmitting(true);
+    try {
+      const res = await signupApi.sendSms(phone.replace(/-/g, ""));
+      const result = await res.json();
+
+      if (result.success) {
+        setIsVerified(false);
+        setCode("");
+        start(180);
+        console.log("SMS 발송 성공:", result.data.flags);
+      } else {
+        alert(result.message || "번호를 확인해주세요.");
+      }
+    } catch (error) {
+      console.error("SMS 요청 에러:", error);
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   const handleResendClick = () => {
@@ -59,17 +79,74 @@ export const ProfileForm = () => {
     handleRequestCode();
   };
 
-  const handleVerify = () => {
-    if (!code || !isCodeRequested || timeLeft === 0) return;
-    const isSuccess = code === "1234";
+  // [STEP 4] 인증번호 확인 (OTP 검증)
+  const handleVerify = async () => {
+    if (!code || !isCodeRequested || timeLeft === 0 || isSubmitting) return;
 
-    if (isSuccess) {
-      setIsVerified(true);
-      setModalType("success");
-      stop();
-    } else {
-      setIsVerified(false);
+    setIsSubmitting(true);
+    try {
+      const res = await signupApi.verifyOtp(code);
+      const result = await res.json();
+
+      // 서버 응답 로그 확인 (중요)
+      console.log("OTP 검증 결과:", result);
+
+      if (result.success && result.data?.step !== "OTP_REQUIRED") {
+        setIsVerified(true);
+        setModalType("success");
+        stop();
+      } else {
+        // 인증번호가 틀린 경우 여기로 들어와야 함
+        setIsVerified(false);
+        setModalType("error");
+      }
+    } catch (error) {
+      console.error("OTP 검증 에러:", error);
       setModalType("error");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  // [STEP 5] 프로필 정보 제출 및 다음 단계 이동
+  const handleModalConfirm = async () => {
+    if (modalType === "error") {
+      setModalType(null);
+      return;
+    }
+
+    if (modalType === "success") {
+      try {
+        // 1. 생년월일 포맷팅 검증 (입력값이 "2026.02.05" 혹은 "20260205"일 경우)
+        const cleanBirth = birth.replace(/\D/g, "");
+
+        if (cleanBirth.length !== 8) {
+          alert("생년월일 8자리를 정확히 입력해주세요.");
+          return;
+        }
+
+        const formattedBirth = `${cleanBirth.slice(0, 4)}-${cleanBirth.slice(4, 6)}-${cleanBirth.slice(6, 8)}`;
+        // 결과: "2026-02-05"
+
+        console.log("제출 데이터:", { name, birthDate: formattedBirth });
+
+        const res = await signupApi.submitProfile({
+          name,
+          birthDate: formattedBirth,
+        });
+        const result = await res.json();
+
+        if (result.success) {
+          setModalType(null);
+          router.push("/signup/password");
+        } else {
+          // 여기서 "유효하지 않은 요청" alert 발생 중
+          alert(result.message || "프로필 정보 등록에 실패했습니다.");
+          setModalType(null);
+        }
+      } catch (error) {
+        console.error("프로필 제출 에러:", error);
+      }
     }
   };
 
@@ -111,18 +188,6 @@ export const ProfileForm = () => {
     isCodeRequested &&
     timeLeft > 0;
 
-  const handleModalConfirm = () => {
-    if (modalType === "success") {
-      setModalType(null);
-      router.push("/signup/password");
-    } else {
-      setModalType(null);
-      stop();
-      setCode("");
-      setIsVerified(false);
-    }
-  };
-
   return (
     <div className="mt-[18px] flex flex-1 flex-col gap-4">
       <div className="px-4">
@@ -159,7 +224,11 @@ export const ProfileForm = () => {
       />
 
       <div className="mt-auto mb-13 flex w-full justify-center px-4 py-[10px]">
-        <FullButton isActive={isConfirmActive} onClick={handleFullButtonClick}>
+        <FullButton
+          isActive={isConfirmActive}
+          onClick={handleFullButtonClick}
+          disabled={isSubmitting}
+        >
           인증하기
         </FullButton>
       </div>

--- a/src/components/signup/ProfileForm.tsx
+++ b/src/components/signup/ProfileForm.tsx
@@ -72,7 +72,7 @@ export const ProfileForm = () => {
         setIsVerified(false);
         setCode("");
         start(180);
-        console.log("SMS 발송 성공:", result.data.flags);
+        console.log("SMS 발송 성공:");
       } else {
         alert(result.message || "문자 발송 제한을 초과했습니다.");
       }
@@ -154,8 +154,6 @@ export const ProfileForm = () => {
         }
 
         const formattedBirth = `${cleanBirth.slice(0, 4)}-${cleanBirth.slice(4, 6)}-${cleanBirth.slice(6, 8)}`;
-
-        console.log("제출 데이터:", { name, birthDate: formattedBirth });
 
         const res = await signupApi.submitProfile({
           name,

--- a/src/components/signup/ProfileForm.tsx
+++ b/src/components/signup/ProfileForm.tsx
@@ -90,14 +90,28 @@ export const ProfileForm = () => {
 
       console.log("OTP 검증 결과:", result);
 
+      //검증 성공 시
       if (result.success && result.data?.step !== "OTP_REQUIRED") {
         setIsVerified(true);
         setModalType("success");
         stop();
-      } else {
-        // 인증번호가 틀린 경우 여기로 들어와야 함
-        setIsVerified(false);
-        setModalType("error");
+      }
+      //검증 실패 시
+      else {
+        const remainingAttempts = result.data?.flags?.remainingOtpAttempts;
+
+        if (remainingAttempts === 0) {
+          alert("인증 시도 횟수를 초과했습니다. 인증번호를 다시 요청해주세요.");
+          stop();
+          setIsVerified(false);
+          setCode("");
+        } else {
+          // 남은 횟수 안내 포함 에러 처리
+          alert(
+            `인증번호가 올바르지 않습니다. (남은 횟수: ${remainingAttempts}회)`,
+          );
+          setModalType("error");
+        }
       }
     } catch (error) {
       console.error("OTP 검증 에러:", error);

--- a/src/components/signup/ProfileForm.tsx
+++ b/src/components/signup/ProfileForm.tsx
@@ -66,6 +66,7 @@ export const ProfileForm = () => {
       }
     } catch (error) {
       console.error("SMS 요청 에러:", error);
+      alert("네트워크 오류가 발생했습니다.");
     } finally {
       setIsSubmitting(false);
     }
@@ -143,6 +144,8 @@ export const ProfileForm = () => {
         }
       } catch (error) {
         console.error("프로필 제출 에러:", error);
+        alert("네트워크 오류가 발생했습니다.");
+        setModalType(null);
       } finally {
         setIsSubmitting(false);
       }

--- a/src/components/signup/ProfileForm.tsx
+++ b/src/components/signup/ProfileForm.tsx
@@ -224,9 +224,8 @@ export const ProfileForm = () => {
 
       <div className="mt-auto mb-13 flex w-full justify-center px-4 py-[10px]">
         <FullButton
-          isActive={isConfirmActive}
+          isActive={isConfirmActive && !isSubmitting}
           onClick={handleFullButtonClick}
-          disabled={isSubmitting}
         >
           인증하기
         </FullButton>

--- a/src/components/signup/ProfileForm.tsx
+++ b/src/components/signup/ProfileForm.tsx
@@ -9,7 +9,6 @@ import { signupApi } from "@/app/api/signup";
 import DateIcon from "@/assets/date.svg";
 import ErrorIcon from "@/assets/modal_error.svg";
 import SuccessIcon from "@/assets/modal_success.svg";
-import PhoneIcon from "@/assets/phone.svg";
 import ProfileIcon from "@/assets/profile.svg";
 
 import { FullButton } from "@/components/common/FullButton";
@@ -88,7 +87,6 @@ export const ProfileForm = () => {
       const res = await signupApi.verifyOtp(code);
       const result = await res.json();
 
-      // 서버 응답 로그 확인 (중요)
       console.log("OTP 검증 결과:", result);
 
       if (result.success && result.data?.step !== "OTP_REQUIRED") {
@@ -117,7 +115,6 @@ export const ProfileForm = () => {
 
     if (modalType === "success") {
       try {
-        // 1. 생년월일 포맷팅 검증 (입력값이 "2026.02.05" 혹은 "20260205"일 경우)
         const cleanBirth = birth.replace(/\D/g, "");
 
         if (cleanBirth.length !== 8) {
@@ -126,7 +123,6 @@ export const ProfileForm = () => {
         }
 
         const formattedBirth = `${cleanBirth.slice(0, 4)}-${cleanBirth.slice(4, 6)}-${cleanBirth.slice(6, 8)}`;
-        // 결과: "2026-02-05"
 
         console.log("제출 데이터:", { name, birthDate: formattedBirth });
 
@@ -140,7 +136,6 @@ export const ProfileForm = () => {
           setModalType(null);
           router.push("/signup/password");
         } else {
-          // 여기서 "유효하지 않은 요청" alert 발생 중
           alert(result.message || "프로필 정보 등록에 실패했습니다.");
           setModalType(null);
         }

--- a/src/components/signup/ProfileForm.tsx
+++ b/src/components/signup/ProfileForm.tsx
@@ -45,24 +45,36 @@ export const ProfileForm = () => {
   const isNameFilled = name.trim().length > 0;
   const canRequestCode = isValidPhone;
   const isBirthValid = isValidBirth(birth);
+  const [remainingResend, setRemainingResend] = useState(3);
 
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleRequestCode = async () => {
     if (!canRequestCode || isSubmitting) return;
 
+    //재전송 횟수 체크
+    if (remainingResend === 0) {
+      alert(
+        "문자 재발송 횟수를 모두 사용하셨습니다. 처음부터 다시 시도해주세요.",
+      );
+      router.replace("/signup/agree"); // 처음으로 리다이렉트
+      return;
+    }
     setIsSubmitting(true);
     try {
       const res = await signupApi.sendSms(phone.replace(/-/g, ""));
       const result = await res.json();
 
       if (result.success) {
+        const { remainingResendCount } = result.data.flags;
+        setRemainingResend(remainingResendCount);
+
         setIsVerified(false);
         setCode("");
         start(180);
         console.log("SMS 발송 성공:", result.data.flags);
       } else {
-        alert(result.message || "번호를 확인해주세요.");
+        alert(result.message || "문자 발송 제한을 초과했습니다.");
       }
     } catch (error) {
       console.error("SMS 요청 에러:", error);
@@ -101,7 +113,9 @@ export const ProfileForm = () => {
         const remainingAttempts = result.data?.flags?.remainingOtpAttempts;
 
         if (remainingAttempts === 0) {
-          alert("인증 시도 횟수를 초과했습니다. 인증번호를 다시 요청해주세요.");
+          alert(
+            "인증 시도 횟수(3회)를 초과했습니다. 인증번호를 다시 요청해주세요.",
+          );
           stop();
           setIsVerified(false);
           setCode("");

--- a/src/components/signup/ProfileForm.tsx
+++ b/src/components/signup/ProfileForm.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from "next/navigation";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { signupApi } from "@/app/api/signup";
 
@@ -114,6 +114,8 @@ export const ProfileForm = () => {
     }
 
     if (modalType === "success") {
+      if (isSubmitting) return;
+      setIsSubmitting(true);
       try {
         const cleanBirth = birth.replace(/\D/g, "");
 
@@ -141,6 +143,8 @@ export const ProfileForm = () => {
         }
       } catch (error) {
         console.error("프로필 제출 에러:", error);
+      } finally {
+        setIsSubmitting(false);
       }
     }
   };

--- a/src/stores/useSignupStore.ts
+++ b/src/stores/useSignupStore.ts
@@ -1,26 +1,29 @@
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 
+interface Term {
+  code: string;
+  version: string;
+  title: string;
+  required: boolean;
+}
+
 interface SignupState {
   draftKey: string | null;
-  currentStep: string;
-  setDraftKey: (key: string) => void;
-  setCurrentStep: (step: string) => void;
-  resetSignup: () => void;
+  terms: Term[];
+  setSignupData: (draftKey: string, terms: Term[]) => void;
 }
 
 export const useSignupStore = create<SignupState>()(
   persist(
     set => ({
       draftKey: null,
-      currentStep: "START",
-      setDraftKey: key => set({ draftKey: key }),
-      setCurrentStep: step => set({ currentStep: step }),
-      resetSignup: () => set({ draftKey: null, currentStep: "START" }),
+      terms: [],
+      setSignupData: (draftKey, terms) => set({ draftKey, terms }),
     }),
     {
       name: "signup-storage",
-      storage: createJSONStorage(() => sessionStorage), // 세션 종료 시 초기화
+      storage: createJSONStorage(() => sessionStorage),
     },
   ),
 );

--- a/src/stores/useSignupStore.ts
+++ b/src/stores/useSignupStore.ts
@@ -1,0 +1,26 @@
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+
+interface SignupState {
+  draftKey: string | null;
+  currentStep: string;
+  setDraftKey: (key: string) => void;
+  setCurrentStep: (step: string) => void;
+  resetSignup: () => void;
+}
+
+export const useSignupStore = create<SignupState>()(
+  persist(
+    set => ({
+      draftKey: null,
+      currentStep: "START",
+      setDraftKey: key => set({ draftKey: key }),
+      setCurrentStep: step => set({ currentStep: step }),
+      resetSignup: () => set({ draftKey: null, currentStep: "START" }),
+    }),
+    {
+      name: "signup-storage",
+      storage: createJSONStorage(() => sessionStorage), // 세션 종료 시 초기화
+    },
+  ),
+);


### PR DESCRIPTION
### 🔥 작업 내용

- 로그인 API
- 회원가입 draft 생성
- 약관동의 목록 조회
- 인증번호 SMS 발송
- OTP 검증
- 프로필 정보 제출
- 비밀번호 설정
- OTP 검증 로직 병합(문자 시도 횟수, 인증 시도 횟수 제한 추가)

### 🤔 추후 작업 사항


### 📸 작업 내역 스크린샷

-

### 🔗 이슈

- 링크 
#34 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 로그인(전화번호/비밀번호)에서 요청 로딩 상태 및 중복 방지, 토큰 저장/이동 처리 추가
  * 회원가입 단계별(임시저장→약관→SMS OTP→프로필→비밀번호) 서버 연동 API 및 클라이언트 흐름 통합
  * 클라이언트용 회원가입 유틸(signupApi) 및 서버 프록시 엔드포인트 추가
  * 회원가입 상태(임시키·약관)를 세션에 영속화하는 저장소 도입

* **Style**
  * 로그인·회원가입 버튼과 로딩 표시, 레이아웃 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->